### PR TITLE
Added test for Literal to support python 3.7 and below.  

### DIFF
--- a/src/dbacademy/dougrest/runs.py
+++ b/src/dbacademy/dougrest/runs.py
@@ -1,4 +1,9 @@
-from typing import Union, Optional, Literal
+from typing import Union, Optional, List
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from dbacademy.rest.common import DatabricksApiException, ApiContainer
 

--- a/src/dbacademy/rest/common.py
+++ b/src/dbacademy/rest/common.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Container, Dict, List, Literal, Type, TypeVar, Union
+from typing import Any, Container, Dict, List, Type, TypeVar, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from pprint import pformat
 from dbacademy.common import deprecated, print_warning
 import requests

--- a/src/dbacademy/rest/permissions/crud.py
+++ b/src/dbacademy/rest/permissions/crud.py
@@ -1,4 +1,10 @@
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from dbacademy.rest.common import *
 
 


### PR DESCRIPTION
Literal wasn't added to typing until python 3.8.  Prior to this it was in typing_extensions.  The version of databricks I am running is still on v3.7.